### PR TITLE
Move stylelint-rule-tester to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   },
   "homepage": "https://github.com/timothyneiljohnson/stylelint-value-shorthand#readme",
   "devDependencies": {
-    "tape": "^4.2.2"
+    "tape": "^4.2.2",
+    "stylelint-rule-tester": "^0.6.1"
   },
   "dependencies": {
     "object-assign": "^4.0.1",
-    "stylelint": ">=3.0.2",
-    "stylelint-rule-tester": "^0.6.1"
+    "stylelint": ">=3.0.2"
   }
 }


### PR DESCRIPTION
stylelint-rule-tester in not need for an end user, because it's using only for plugin development. Now when user installs the plugin, npm also install stylelint-rule-tester and tape (stylelint-rule-tester's dependency).
