### PR TITLE
Add plugin namespace to sort styleline warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ As follows:
     "stylelint-value-shorthand"
   ],
   "rules": {
-    "value-shorthand": true
+    "plugin/value-shorthand": true
   }
 };
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const assign = require('object-assign');
 const stylelint = require('stylelint');
-const ruleName = 'value-shorthand';
+const ruleName = 'plugin/value-shorthand';
 const messages = stylelint.utils.ruleMessages(ruleName, {});
 
 const arrayContains = (searchItem, array) =>


### PR DESCRIPTION
Fixes deprecation warning: `‼  Plugin rules that aren't namespaced have been deprecated, and in 7.0 they wl be disallowed. [stylelint]`
